### PR TITLE
Adding remote profile and Add endpoint to get it

### DIFF
--- a/Account.API/Controllers/AccountController.cs
+++ b/Account.API/Controllers/AccountController.cs
@@ -152,6 +152,33 @@ namespace Account.API.Controllers
             return Ok(profile);
         }
 
+        /// <summary>
+        /// Retrieve limited profile data for a given user by ID.
+        /// </summary>
+        [HttpGet("GetRemoteProfileData/{userId}")]
+        public async Task<ActionResult<RemoteProfileData>> GetRemoteProfileData(string userId)
+        {
+            if (string.IsNullOrEmpty(userId))
+                return BadRequest("User ID is required.");
+
+            // Fetch the full profile model from the service
+            var profile = await _accountService.GetProfileAsync(userId);
+            if (profile == null)
+                return NotFound("Profile not found.");
+
+            // Map ProfileData to RemoteProfileData
+            var remoteProfile = new RemoteProfileData
+            {
+                UserId = profile.Profile.UserId,
+                Username = profile.Profile.Username,
+                ProfilePictureId = profile.Profile.ProfilePictureId,
+                BannerPictureId = profile.Profile.BannerPictureId,
+                Club = profile.Profile.Club
+            };
+
+            return Ok(remoteProfile);
+        }
+
         private string GenerateUniqueUsername()
         {
             const int maxRetries = 10000;

--- a/Account.API/Models/Profile/Utils/RemoteProfileData.cs
+++ b/Account.API/Models/Profile/Utils/RemoteProfileData.cs
@@ -1,0 +1,14 @@
+﻿namespace Account.API.Models.Profile.Utils
+{
+    // This model represents a remote profile data structure that can be retrieved when accessing another user's profile. 
+    // It provides limited information to respect privacy, including basic identifiers and public display elements like 
+    // username, profile picture, banner picture, and club affiliation. Used in scenarios where full profile details 
+    public class RemoteProfileData
+    {
+        public string? UserId { get; set; } = null!;
+        public string Username { get; set; } = null!;
+        public string ProfilePictureId { get; set; } = null!;
+        public string BannerPictureId { get; set; } = null!;
+        public string Club { get; set; } = null!;
+    }
+}


### PR DESCRIPTION
Adding a method to retrieve a remote profile containing limited information, allowing us to share basic details about other players without sensitive data such as currency balance, email, or password 